### PR TITLE
add 1889 history

### DIFF
--- a/history/09.30.md
+++ b/history/09.30.md
@@ -2,3 +2,6 @@
 The first volume of Louisa May Alcott’s beloved children’s book Little Women
 is published on this day. The novel will become Alcott’s first bestseller
 and a beloved children’s classic.
+
+# 1889
+On this day in 1889, the Wyoming state convention approves a constitution that includes a provision granting women the right to vote. Formally admitted into the union the following year, Wyoming thus became the first state in the history of the nation to allow its female citizens to vote.


### PR DESCRIPTION
Wyoming first state to allow women to vote.
